### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dependencies {
   /** 
    * Any other dependencies your module has are placed in this dependency configuration
    */
-  compile 'com.adcolony:sdk:3.3.5'
+  implementation 'com.adcolony:sdk:3.3.5'
 }
 ```
 


### PR DESCRIPTION
Modify the README to change Gradle installation configuration keyword from compile to implementation. In Android Gradle plugin 3.0 the compile configuration still exists but should not be used as it will not offer the guarantees that the api and implementation configurations provide. 